### PR TITLE
Improve updateFirmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,16 @@ Esp32OtaPackage otaPackage = Esp32OtaPackage(notifyCharacteristic, dataCharacter
     * `FirmwareType.filepicker`: To select a binary firmware file from the device storage.
     * `FirmwareType.url`: For downloading firmware from a URL.
 
-5. (Optional) Provide the path to the binary firmware file (`binFilePath`) if `firmwareType` is set to `FirmwareType.assets`.
+5. (Optional) `uri`: Provide the path to the binary firmware file if `firmwareType` is set to `FirmwareType.assets` OR provide the URL of the firmware file if `firmwareType` is set to `FirmwareType.url`.
 
-6. (Optional) Provide the URL of the firmware file if `firmwareType` is set to `FirmwareType.url`.
-
-7. Call the `updateFirmware` method of the `otaPackage` instance:
+6. Call the `updateFirmware` method of the `otaPackage` instance:
 
 ```dart
 await otaPackage.updateFirmware(
   device,
   updateType,
   firmwareType,
-  binFilePath: binFilePath,
-  url: url,
+  uri: uri,
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,6 @@ await otaPackage.updateFirmware(
   device,
   updateType,
   firmwareType,
-  service,
-  dataCharacteristic,
-  notifyCharacteristic,
   binFilePath: binFilePath,
   url: url,
 );

--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ Esp32OtaPackage otaPackage = Esp32OtaPackage(notifyCharacteristic, dataCharacter
 4. Choose the firmware update type (`updateType`) and firmware type (`firmwareType`):
 
 * `updateType`:
-    * Update Type 1: ESP-IDF/Espressif Firmware Update
-      If updateType is set to 1, it indicates that the firmware update follows the ESP-IDF/Espressif framework. In this case, you'll typically perform OTA updates using binary files and utilize the NimBLE Bluetooth stack.
+    * `UpdateType.espidf`: ESP-IDF/Espressif Firmware Update
+      This indicates that the firmware update follows the ESP-IDF/Espressif framework. In this case, you'll typically perform OTA updates using binary files and utilize the NimBLE Bluetooth stack.
 
-    * Update Type 2: Arduino IDE-Based Firmware Update
-      If updateType is set to 2, it suggests that the firmware update is based on the Arduino framework for ESP32. This could involve custom OTA update logic implemented on the ESP32 side, possibly using specific GATT services and characteristics for communication.
+    * `UpdateType.arduino`: Arduino IDE-Based Firmware Update
+      This suggests that the firmware update is based on the Arduino framework for ESP32. This could involve custom OTA update logic implemented on the ESP32 side, possibly using specific GATT services and characteristics for communication.
       By checking the updateType parameter, you can adapt your OTA update logic to the specific requirements of the firmware implementation. This ensures compatibility and seamless OTA updates for different types of ESP32 firmware.
+
 * `firmwareType`:
     * 1: For binary firmware files stored in your Flutter project assets.
     * 2: To select a binary firmware file from the device storage.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Esp32OtaPackage otaPackage = Esp32OtaPackage(notifyCharacteristic, dataCharacter
       By checking the updateType parameter, you can adapt your OTA update logic to the specific requirements of the firmware implementation. This ensures compatibility and seamless OTA updates for different types of ESP32 firmware.
 
 * `firmwareType`:
-    * 1: For binary firmware files stored in your Flutter project assets.
-    * 2: To select a binary firmware file from the device storage.
-    * 3: For downloading firmware from a URL.
+    * `FirmwareType.assets`: For binary firmware files stored in your Flutter project assets.
+    * `FirmwareType.filepicker`: To select a binary firmware file from the device storage.
+    * `FirmwareType.url`: For downloading firmware from a URL.
 
-5. (Optional) Provide the path to the binary firmware file (`binFilePath`) if `firmwareType` is set to 1.
+5. (Optional) Provide the path to the binary firmware file (`binFilePath`) if `firmwareType` is set to `FirmwareType.assets`.
 
-6. (Optional) Provide the URL of the firmware file if `firmwareType` is set to 3.
+6. (Optional) Provide the URL of the firmware file if `firmwareType` is set to `FirmwareType.url`.
 
 7. Call the `updateFirmware` method of the `otaPackage` instance:
 

--- a/example/lib/features/scanningAndConnection/presentation/view/ota_update_page.dart
+++ b/example/lib/features/scanningAndConnection/presentation/view/ota_update_page.dart
@@ -186,25 +186,12 @@ class _NewOTAUpdatePageState extends State<NewOTAUpdatePage> {
                           );
 
                           // Perform the OTA update with the picked binfile
-                          await esp32otaPackage!.updateFirmware(
+                          await esp32otaPackage.updateFirmware(
                             device,
                             1, //Update Type
                             1,
-                            service,
-                            notifyUuid,
-                            writeUuid,
                             binFilePath: "assets/helllo.ino.bin",
                           );
-                          /*if (binfile != null) {
-                              await esp32otaPackage.updateFirmware(
-                                device,
-                                1,
-                                service,
-                                dataUuid,
-                                controlUuid,
-                                binFilePath: "assets/helllo.ino.bin",
-                              );
-                            }*/
 
                           // Initialize BleUartController before sending a command
                           // bleUartController.init();

--- a/example/lib/features/scanningAndConnection/presentation/view/ota_update_page.dart
+++ b/example/lib/features/scanningAndConnection/presentation/view/ota_update_page.dart
@@ -188,7 +188,7 @@ class _NewOTAUpdatePageState extends State<NewOTAUpdatePage> {
                           // Perform the OTA update with the picked binfile
                           await esp32otaPackage.updateFirmware(
                             device,
-                            1, //Update Type
+                            UpdateType.espidf,
                             1,
                             binFilePath: "assets/helllo.ino.bin",
                           );

--- a/example/lib/features/scanningAndConnection/presentation/view/ota_update_page.dart
+++ b/example/lib/features/scanningAndConnection/presentation/view/ota_update_page.dart
@@ -189,7 +189,7 @@ class _NewOTAUpdatePageState extends State<NewOTAUpdatePage> {
                           await esp32otaPackage.updateFirmware(
                             device,
                             UpdateType.espidf,
-                            1,
+                            FirmwareType.assets,
                             binFilePath: "assets/helllo.ino.bin",
                           );
 

--- a/example/lib/features/scanningAndConnection/presentation/view/ota_update_page.dart
+++ b/example/lib/features/scanningAndConnection/presentation/view/ota_update_page.dart
@@ -190,7 +190,7 @@ class _NewOTAUpdatePageState extends State<NewOTAUpdatePage> {
                             device,
                             UpdateType.espidf,
                             FirmwareType.assets,
-                            binFilePath: "assets/helllo.ino.bin",
+                            uri: "assets/helllo.ino.bin",
                           );
 
                           // Initialize BleUartController before sending a command

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: fedaadfa3a6996f75211d835aaeb8fede285dae94262485698afd832371b9a5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+8"
   crypto:
     dependency: transitive
     description:
@@ -141,10 +149,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.8"
   dart_style:
     dependency: transitive
     description:
@@ -197,10 +205,10 @@ packages:
     dependency: "direct dev"
     description:
       name: file_picker
-      sha256: be325344c1f3070354a1d84a231a1ba75ea85d413774ec4bdf444c023342e030
+      sha256: d1d0ac3966b36dc3e66eeefb40280c17feb87fa2099c6e22e6a1fc959327bd03
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "8.0.0+1"
   fixnum:
     dependency: transitive
     description:
@@ -233,11 +241,10 @@ packages:
   flutter_ota:
     dependency: "direct dev"
     description:
-      name: flutter_ota
-      sha256: "6382ad4a666b30b6640287ff32313ac91d139909069426b725555425c0619800"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.11"
+      path: ".."
+      relative: true
+    source: path
+    version: "0.1.15"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -268,10 +275,10 @@ packages:
     dependency: "direct dev"
     description:
       name: get
-      sha256: "2ba20a47c8f1f233bed775ba2dd0d3ac97b4cf32fc17731b3dfc672b06b0e92a"
+      sha256: e4e7335ede17452b391ed3b2ede016545706c01a02292a6c97619705e7d2a85e
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.5"
+    version: "4.6.6"
   glob:
     dependency: transitive
     description:
@@ -468,42 +475,50 @@ packages:
     dependency: "direct dev"
     description:
       name: permission_handler
-      sha256: bc56bfe9d3f44c3c612d8d393bd9b174eb796d706759f9b495ac254e4294baa5
+      sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"
       url: "https://pub.dev"
     source: hosted
-    version: "10.4.5"
+    version: "11.3.1"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "59c6322171c29df93a22d150ad95f3aa19ed86542eaec409ab2691b8f35f9a47"
+      sha256: b29a799ca03be9f999aa6c39f7de5209482d638e6f857f6b93b0875c618b7e54
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.6"
+    version: "12.0.7"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: "99e220bce3f8877c78e4ace901082fb29fa1b4ebde529ad0932d8d664b34f3f5"
+      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.4"
+    version: "9.4.5"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "54bf176b90f6eddd4ece307e2c06cf977fb3973719c35a93b85cc7093eb6070d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: "6760eb5ef34589224771010805bea6054ad28453906936f843a8cc4d3a55c4a4"
+      sha256: "48d4fcf201a1dad93ee869ab0d4101d084f49136ec82a8a06ed9cfeacab9fd20"
       url: "https://pub.dev"
     source: hosted
-    version: "3.12.0"
+    version: "4.2.1"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      sha256: cc074aace208760f1eee6aa4fae766b45d947df85bc831cde77009cdb4720098
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.1"
   platform:
     dependency: transitive
     description:
@@ -633,10 +648,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "350a11abd2d1d97e0cc7a28a81b781c08002aa2864d9e3f192ca0ffa18b06ed3"
+      sha256: "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.9"
+    version: "5.2.0"
   win32_registry:
     dependency: transitive
     description:
@@ -663,4 +678,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.10.0"
+  flutter: ">=3.16.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -49,11 +49,12 @@ dev_dependencies:
   fluttertoast: ^8.2.2
   bluetooth_enable_fork: ^0.1.6
   device_info_plus: ^9.0.0
-  permission_handler: ^10.2.0
+  permission_handler: ^11.3.1
   path_provider: ^2.0.15
-  file_picker: ^5.3.3
+  file_picker: ^8.0.0+1
   http: ^1.2.0
-  flutter_ota: ^0.1.11
+  flutter_ota:
+    path: ..
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/lib/ota_package.dart
+++ b/lib/ota_package.dart
@@ -19,7 +19,7 @@ abstract class OtaPackage {
   /// [url]: The URL to fetch firmware from (optional).
   Future<void> updateFirmware(
       BluetoothDevice device,
-      int updateType,
+      UpdateType updateType,
       int firmwareType,
       {String? binFilePath,
       String? url});
@@ -29,6 +29,11 @@ abstract class OtaPackage {
 
   /// Stream to provide progress percentage
   Stream<int> get percentageStream;
+}
+
+enum UpdateType {
+  espidf,
+  arduino,
 }
 
 /// A class responsible for handling BLE repository operations.
@@ -311,11 +316,11 @@ class Esp32OtaPackage implements OtaPackage {
   @override
   Future<void> updateFirmware(
       BluetoothDevice device,
-      int updateType,
+      UpdateType updateType,
       int firmwareType,
       {String? binFilePath,
       String? url}) async {
-    if (updateType == 1) {
+    if (updateType == UpdateType.espidf) {
       final bleRepo = BleRepository();
 
       /// Get MTU size from the device
@@ -384,7 +389,7 @@ class Esp32OtaPackage implements OtaPackage {
         print('OTA update failed');
         firmwareUpdate = false; // Firmware update failed
       }
-    } else if (updateType == 2) {
+    } else if (updateType == UpdateType.arduino) {
 
       final bleRepo = BleRepository();
 

--- a/lib/ota_package.dart
+++ b/lib/ota_package.dart
@@ -15,18 +15,12 @@ abstract class OtaPackage {
   /// [device]: The Bluetooth device to update firmware on.
   /// [updateType]: The type of update operation.
   /// [firmwareType]: The type of firmware to update.
-  /// [service]: The Bluetooth service for firmware update.
-  /// [dataUUID]: The UUID of the Bluetooth characteristic for data transfer.
-  /// [controlUUID]: The UUID of the Bluetooth characteristic for control commands.
   /// [binFilePath]: The file path of the firmware binary (optional).
   /// [url]: The URL to fetch firmware from (optional).
   Future<void> updateFirmware(
       BluetoothDevice device,
       int updateType,
       int firmwareType,
-      BluetoothService service,
-      BluetoothCharacteristic dataUUID,
-      BluetoothCharacteristic controlUUID,
       {String? binFilePath,
       String? url});
 
@@ -319,9 +313,6 @@ class Esp32OtaPackage implements OtaPackage {
       BluetoothDevice device,
       int updateType,
       int firmwareType,
-      BluetoothService service,
-      BluetoothCharacteristic dataUUID,
-      BluetoothCharacteristic controlUUID,
       {String? binFilePath,
       String? url}) async {
     if (updateType == 1) {


### PR DESCRIPTION
**Breaking change: Refactor of OTA Update Enums and Parameters**
- Introduced UpdateType and FirmwareType enums to improve readability and reduce reliance on arbitrary integer values for updateType and firmwareType
- simplified binFilePath and url parameters into a single uri parameter

**OTA Update Logic Improvements**
- improve sendPart function to dynamically adapt to the device’s mtu size, closes https://github.com/sparkleo-io/flutter_ota/issues/18

CC @Neolyum